### PR TITLE
Add cname to the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./build
+          cname: embedded-rust-101.wyliodrin.com
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes cname in the deployer's settings. Without this, everytime the website is deployed, the custom domain is overwritten to the github default domain.


### Testing Strategy

This pull request was not tested, will be tested as soon as this is merged and a publish is done.


### TODO or Help Wanted

N/A


### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Alexandru Radovici <alexandru.radovici@wyliodrin.com>
