### PR TITLE
Rename homework label to project label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,8 +4,9 @@ lecture:
 lab:
   - docs/lab/**/*
 
-homework:
-  - docs/homework/**/*
+project:
+  - docs/project/**/*
+  - docs/project.md
 
 workflow:
   - .github/**/*


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the project label by renaming the `homework` label to `project`.


### Testing Strategy

This pull request will be tested as soon as it is merged and a pull request is made to modify the project description.


### TODO or Help Wanted

N/A


### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Alexandru Radovici <alexandru.radovici@wyliodrin.com>
