### PR TITLE
removed double `unsafe` block

### DIFF
--- a/docs/lab/02/02.md
+++ b/docs/lab/02/02.md
@@ -251,10 +251,10 @@ unsafe {
     // clear bit `5` of the `RESET` register by
     // writing `1` on  bit `5` at address
     // `RESET` + 0x3000
-    unsafe { write_volatile((RESET + CLR) as *mut u32, 1 << 5); }
+    write_volatile((RESET + CLR) as *mut u32, 1 << 5);
 
     // wait for the IO Bank0 to enable
-    while unsafe { read_volatile(RESET_DONE as *const u32) } & (1 << 5) == 0 {}
+    while read_volatile(RESET_DONE as *const u32) & (1 << 5) == 0 {}
 }
 ```
 


### PR DESCRIPTION
### Pull Request Overview

This pull request removes double `unsafe` from an example


### Build

- [x] Ran `npm build`.

### Author

Signed-off-by: Aldea George Danut <danutz.aldea23@gmail.com>
