### PR TITLE
Replace steal with take in Lab 2

### DIFF
--- a/docs/lab/02/02.md
+++ b/docs/lab/02/02.md
@@ -429,7 +429,7 @@ use rp2040_pac::Peripherals;
 #[entry]
 fn main() -> ! {
     // get a reference to all the peripherals
-    let peripherals = unsafe { Peripherals::steal() };
+    let mut peripherals = Peripherals::take().unwrap();
 
     loop { }
 }

--- a/docs/lab/02/02.md
+++ b/docs/lab/02/02.md
@@ -429,7 +429,7 @@ use rp2040_pac::Peripherals;
 #[entry]
 fn main() -> ! {
     // get a reference to all the peripherals
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
 
     loop { }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request replaces the unsafe `steal` function with `take` when getting a reference to all peripherals, in Lab 2.


### Testing Strategy

This pull request was tested by comparing with Lab 3.


### TODO or Help Wanted

This pull request still needs review.

### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Teodora Miu <teodora.miu@stud.fils.upb.ro>
