### PR TITLE
changed the code snippet from cs.set_low() to cs.set_high()

### DIFF
--- a/docs/lab/06/index.md
+++ b/docs/lab/06/index.md
@@ -177,7 +177,7 @@ spi.transfer(&mut rx_buf, &tx_buf).await;
 Once we are done with the transfer, we set the `cs` line back to `high` to deactivate the sub.
 
 ```rust
-cs.set_low();
+cs.set_high();
 ```
 
 ## Digital vs Analog sensors


### PR DESCRIPTION
As stated in the message above the corrected snippet, once the data has been transfered, I think the chip select should be set to high to make the sub inactive.

### Pull Request Overview

This pull request adds/changes/fixes...


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Your Name <Your Email@example.com>
