### PR TITLE
Fix CS pin

### DIFF
--- a/docs/lab/06/index.md
+++ b/docs/lab/06/index.md
@@ -371,7 +371,7 @@ To control the buzzer, all you need to do is to set the `top` value of the PWM c
 
 ## Exercises
 
-1. Connect the BMP280. Use the wiring configuration for the SPI, and connect the CS to GPIO 3. Next, connect the buzzer (with a resistance) to GPIO 1. Use Kicad to draw the schematic. (**1p**)
+1. Connect the BMP280. Use the wiring configuration for the SPI, and connect the CS to GPIO 5. Next, connect the buzzer (with a resistance) to GPIO 1. Use Kicad to draw the schematic. (**1p**)
 2. The example provided for exercise 2 in the lab skeleton is a basic example of how to read a register of the BMP280. Modify it to read the `id` of the BMP280 and print it over serial. (**1p**)
 
 :::tip


### PR DESCRIPTION
### Pull Request Overview

This pull request corrects the pin suggested for the CS connection of the BMP280. 
In the Raspberry Pi Pico pinout image, we can notice that GPIO3 is used for the SPIO0 MOSI, thus the right pin to connect BMP280's CSB pin to is GPIO5.
![image](https://github.com/UPB-FILS-MA/upb-fils-ma.github.io/assets/94986973/1549f060-5402-4a5a-847b-aece8845c8e7)



### Testing Strategy

This pull request was tested by Alberto Udrea


### TODO or Help Wanted

-


### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Alberto Udrea <albertoudrea4@gmail.com>
