### PR TITLE
Volatile is not the same as no cache

### DIFF
--- a/slides/lectures/02/mmio/slides.md
+++ b/slides/lectures/02/mmio/slides.md
@@ -133,7 +133,7 @@ with cache
 # No Cache or Flush Cache
 
 - Cache types:
-  - *write-trough* - data is written to the cache and to the main memory (bus)
+  - *write-through* - data is written to the cache and to the main memory (bus)
   - *write-back* - data is written to the cache and later to the main memory (bus)
 - few Cortex-M MCUs have cache
 - the Memory Mapped region is set as *nocache*

--- a/slides/lectures/02/mmio/slides.md
+++ b/slides/lectures/02/mmio/slides.md
@@ -139,7 +139,8 @@ with cache
 - the Memory Mapped I/O region is set as *nocache*
 - for chips that use cache
   - *nocache* regions have to be set manually (if MCU knows)
-  - the cache has to be flushed before every `volatile_read` and after `volatile_write`
+  - or, the cache has to be flushed before a `volatile_read` and after a `volatile_write`
+  - beware DMA controllers that can't see the cache contents
 
 ---
 layout: two-cols

--- a/slides/lectures/02/mmio/slides.md
+++ b/slides/lectures/02/mmio/slides.md
@@ -136,7 +136,7 @@ with cache
   - *write-through* - data is written to the cache and to the main memory (bus)
   - *write-back* - data is written to the cache and later to the main memory (bus)
 - few Cortex-M MCUs have cache
-- the Memory Mapped region is set as *nocache*
+- the Memory Mapped I/O region is set as *nocache*
 - for chips that use cache
   - *nocache* regions have to be set manually (if MCU knows)
   - the cache has to be flushed before every `volatile_read` and after `volatile_write`

--- a/slides/lectures/06/dma/slides.md
+++ b/slides/lectures/06/dma/slides.md
@@ -30,6 +30,20 @@ layout: two-cols
 - due to MMIO, usually implies **transfers from and to peripherals**
 - raises an interrupt when a transfer is done
 
+<v-click>
+
+⚠️ DMA does not know about the data stored in cache.
+
+</v-click>
+
+<v-click>
+
+- for chips that use cache
+  - the DMA buffer's memory region has to be set manually to *nocache* (if MCU knows)
+  - or, the cache has to be flushed before and, possibly after, a DMA transfer
+
+</v-click>
+
 :: right ::
 
 <img src="/dma/dma.svg" class="rounded">


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the statement that `volatile` implies no cache. This pull request closes #113.


### Testing Strategy

This pull request was tested by reading the slides.


### TODO or Help Wanted

This pull request still needs feedback from @jonathanpallant.


### Build

- [x] Ran `npm build`.

### Author

Signed-off-by: Alexandru Radovici <alexandru.radovici@wyliodrin.com>
