### PR TITLE
removed accidental slash after schematics subtitle

### DIFF
--- a/docs/project/2024/andra_ioana.uritu/index.md
+++ b/docs/project/2024/andra_ioana.uritu/index.md
@@ -68,7 +68,7 @@ When an unauthorized pet is trying to enter (the servomotor remains vertical, st
 - **Power Supply**: An external battery to keep the system running independently.
 
 
-### Schematics\
+### Schematics
 This is the KiCad schematic:
 ![Schematic](kicad_schematic.png)
 


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the slash typed accidentally after the "Schematics" subtitle


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Build

- [ ] Ran `npm build`.

### Author

Signed-off-by: Uritu Andra-Ioana <andra_ioana.uritu@stud.fils.upb.ro>
